### PR TITLE
refactors code to use IndicoClientV2

### DIFF
--- a/IndicoToolkit.Tests/ClientTests.cs
+++ b/IndicoToolkit.Tests/ClientTests.cs
@@ -1,22 +1,24 @@
 using System.Net.Http;
 using Xunit;
-using Indico;
+using IndicoV2;
 
 namespace IndicoToolkit.Tests
 {
-    public class ClientTests 
+    public class ClientTests
     {
-        
+
         [Fact]
-        public void TestClientCreation(){
+        public void TestClientCreation()
+        {
             IndicoClient client = new Client(host: "http://app.indico.io", apiTokenString: Utils.api_key).Create();
             Assert.IsType<IndicoClient>(client);
         }
 
         [Fact]
-        public void TestClientFail(){
+        public void TestClientFail()
+        {
             IndicoClient client = new Client(host: "http://app.indico.io", apiTokenString: "not_a_real_token").Create();
-            Assert.ThrowsAsync<HttpRequestException>(() => client.ModelGroupLoad().Exec());
+            Assert.ThrowsAsync<HttpRequestException>(() => client.DataSets().ListFullAsync());
         }
     }
 }

--- a/IndicoToolkit.Tests/Utils.cs
+++ b/IndicoToolkit.Tests/Utils.cs
@@ -1,20 +1,19 @@
 using Newtonsoft.Json;
 using System;
 using System.IO;
-using Indico;
+using IndicoV2;
 using System.Collections.Generic;
 using Newtonsoft.Json.Linq;
 using IndicoToolkit.Types;
 
 namespace IndicoToolkit.Tests
 {
-    public class Utils 
+    public class Utils
     {
         static public string file_dir = Directory.GetParent(Directory.GetCurrentDirectory()).Parent.Parent.FullName;
-        static public string host = Environment.GetEnvironmentVariable("INDICO_HOST");
-        static public string api_key = Environment.GetEnvironmentVariable("INDICO_KEY");                
-        static public IndicoConfig config = new IndicoConfig(host: host, apiToken: api_key);
-        static public IndicoClient client = new IndicoClient(config);
+        static public string host = "http://app.indico.io";
+        static public string api_key = Environment.GetEnvironmentVariable("INDICO_KEY");
+        static public IndicoClient client = new Client(host: host, apiTokenString: api_key).Create();
         public static dynamic LoadJson(string path)
         {
             string file_path = Path.Join(file_dir, path);
@@ -55,8 +54,8 @@ namespace IndicoToolkit.Tests
                     {"testLabel", .9f}
                 };
                 val.Add("confidence", newConfidence);
-            } 
-            else 
+            }
+            else
             {
                 val.Add("confidence", confidence);
             }

--- a/IndicoToolkit.Tests/Utils.cs
+++ b/IndicoToolkit.Tests/Utils.cs
@@ -11,7 +11,7 @@ namespace IndicoToolkit.Tests
     public class Utils
     {
         static public string file_dir = Directory.GetParent(Directory.GetCurrentDirectory()).Parent.Parent.FullName;
-        static public string host = "http://app.indico.io";
+        static public string host = Environment.GetEnvironmentVariable("INDICO_HOST");
         static public string api_key = Environment.GetEnvironmentVariable("INDICO_KEY");
         static public IndicoClient client = new Client(host: host, apiTokenString: api_key).Create();
         public static dynamic LoadJson(string path)

--- a/IndicoToolkit/AutoClassifier.cs
+++ b/IndicoToolkit/AutoClassifier.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using System.Globalization;
-using Indico;
+using IndicoV2;
 using CsvHelper;
 
 using IndicoToolkit.Types;
@@ -35,19 +35,19 @@ namespace IndicoToolkit
         /// <param name="batchSize">Docs to OCR in parallel.</param>
         public async Task setDocumentText(int batchSize = 5)
         {
-            DocExtraction docex = new DocExtraction(this.client);
+            DocExtraction docex = new DocExtraction(client);
             List<List<string>> batches = this.fp.BatchFiles(batchSize).ToList();
             int totalCount = batches.Count;
             int batchCount = 1;
-            foreach(List<string> batch in batches)
+            foreach (List<string> batch in batches)
             {
                 Console.WriteLine($"Starting batch {batchCount} of {totalCount}");
                 List<OnDoc> results = await docex.RunOCR(batch);
-                foreach(OnDoc doc in results)
+                foreach (OnDoc doc in results)
                 {
                     this.fileTexts.Add(doc.GetFullText());
                 }
-                batchCount ++;
+                batchCount++;
             }
         }
 
@@ -62,17 +62,18 @@ namespace IndicoToolkit
                 csv.NextRecord();
                 for (int ind = 0; ind < this.filePaths.Count; ind++)
                 {
-                    DocRecord rec = new DocRecord{
-                            filename=Path.GetFileName(filePaths[ind]), 
-                            docClass=fileClasses[ind], 
-                            docText=fileTexts[ind]
-                        };
+                    DocRecord rec = new DocRecord
+                    {
+                        filename = Path.GetFileName(filePaths[ind]),
+                        docClass = fileClasses[ind],
+                        docText = fileTexts[ind]
+                    };
                     csv.WriteRecord(rec);
                     csv.NextRecord();
                 }
             }
         }
-        
+
         /// <summary>gathers filepaths and sets classes. Must be run prior to createClassifier</summary>
         /// <param name="acceptedTypes">Acceptable file extensions. Defaults to this.acceptedTypes</param>
         public void setFileStructure(List<string> acceptedTypes = null)

--- a/IndicoToolkit/Client.cs
+++ b/IndicoToolkit/Client.cs
@@ -1,40 +1,36 @@
-using Indico;
+using System;
+using IndicoV2;
 
 namespace IndicoToolkit
 {
     /// <summary>
     /// Client for the Indico Toolkit.
     /// </summary>
-    public class Client {
+    public class Client
+    {
         public string Host { get; }
         public string ApiTokenString { get; }
-        public string ApiTokenPath { get; }
         public bool Verify { get; }
 
         public Client(
             string host,
             string apiTokenString = "",
-            string apiTokenPath = "",
             bool verify = true
-        ) {
+        )
+        {
             Host = host;
             ApiTokenString = apiTokenString;
-            ApiTokenPath = apiTokenPath;
             Verify = verify;
         }
 
         /// <summary>
-        /// Instantiates Indico API client.
+        /// Instantiates IndicoV2 API client.
         /// </summary>
-        public IndicoClient Create() {
-            IndicoConfig config = new IndicoConfig(
-                apiToken: ApiTokenString, 
-                tokenPath: ApiTokenPath,
-                host: Host,
-                verify: Verify
-            );
-            return new IndicoClient(config);
-        } 
-        
+        public IndicoClient Create()
+        {
+            Uri hostUri = new Uri(Host);
+            return new IndicoClient(apiToken: ApiTokenString, baseUri: hostUri);
+        }
+
     }
 }

--- a/IndicoToolkit/IndicoToolkit.csproj
+++ b/IndicoToolkit/IndicoToolkit.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="CsvHelper" Version="27.1.1" />
-    <PackageReference Include="IndicoClient" Version="2.3.0" />
+    <PackageReference Include="IndicoClient" Version="2.4.1" />
     <PackageReference Include="System.Linq" Version="4.3.0" />
   </ItemGroup>
 

--- a/IndicoToolkit/Workflows.cs
+++ b/IndicoToolkit/Workflows.cs
@@ -1,4 +1,4 @@
-using Indico;
+using IndicoV2;
 
 namespace IndicoToolkit
 {


### PR DESCRIPTION
Two reasons for this:

- According to c# client documentation, I think the long term plan is to push users toward using this V2 and eventually deprecate V1
- Will make development for Workflows class a lot easier